### PR TITLE
Improved support for Python dictionaries

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1017,11 +1017,11 @@ end
 
 
 """
-    getparams(m::RheoModel; unicode=true)
+    getparams(m::RheoModel; unicode=true, dict=false)
 
 `getparams` return the list of model parameters with their values as a NamedTuple.
 If `unicode` is set to `false`, the unicode symbols are converted their text equivalent.
-
+If `dict` is set to `true`, the output is returned as a dictionary, which is convenient when used with Python.
 
 # Example
 ```@example
@@ -1035,11 +1035,19 @@ julia> getparams(m,unicode=false)
 (k = 1.0, eta = 2.0)
 ``` 
 """
-function getparams(m::RheoModel; unicode=true)
-    if unicode
-        return(m.fixedparams)
+function getparams(m::RheoModel; unicode=true, dict=false)
+    if dict
+        nt=m.fixedparams
+        if !unicode
+            nt=unicode_to_text(nt)
+        end
+        return(Dict(zip(keys(nt),values(nt))))
     else
-        return(unicode_to_text(m.fixedparams))
+        if unicode
+            return(m.fixedparams)
+        else
+            return(unicode_to_text(m.fixedparams))
+        end
     end
 end
 

--- a/src/processing.jl
+++ b/src/processing.jl
@@ -349,9 +349,9 @@ RHEOS makes use of a local derivative free algorithm, specifically the Tom Rowan
 function modelfit(data::RheoTimeData,
                   model::RheoModelClass,
                   modloading::LoadingType;
-                  p0::Union{NamedTuple,Nothing} = nothing,
-                  lo::Union{NamedTuple,Nothing} = nothing,
-                  hi::Union{NamedTuple,Nothing} = nothing,
+                  p0::Union{NamedTuple,Nothing,Dict} = nothing,
+                  lo::Union{NamedTuple,Nothing,Dict} = nothing,
+                  hi::Union{NamedTuple,Nothing,Dict} = nothing,
                   verbose::Bool = false,
                   rel_tol = 1e-4,
                   diff_method="BD",

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -56,6 +56,12 @@ function symbol_to_unicode(nt::Nothing)
     nothing 
 end
 
+# When called from Python, it is useful to accept Dict rather than NamedTuple which are not supported.
+function symbol_to_unicode(d::Dict)    
+    symbol_to_unicode( NamedTuple{([Symbol(e) for e in keys(d)]...,)}(values(d)) )
+end
+
+
 
 function unicode_to_text(s::Symbol)
     r=findfirst(e->e==s, symbol_convertion_table)    

--- a/test/definitions.jl
+++ b/test/definitions.jl
@@ -122,6 +122,14 @@ function _getparams()
 end
 @test _getparams()
 
+function _getparams_dict()
+    m = RheoModel(Maxwell, k=1, eta=2)
+    p = getparams(m,unicode=false,dict=true)
+    (p[:k]==1.0) && (p[:η]==2.0) 
+end
+@test _getparams_dict()
+
+
 
 #
 #   The moduli functions on arrays are extensively tested as part of the model tests

--- a/test/definitions.jl
+++ b/test/definitions.jl
@@ -125,7 +125,7 @@ end
 function _getparams_dict()
     m = RheoModel(Maxwell, k=1, eta=2)
     p = getparams(m,unicode=false,dict=true)
-    (p[:k]==1.0) && (p[:η]==2.0) 
+    (p[:k]==1.0) && (p[:eta]==2.0) 
 end
 @test _getparams_dict()
 

--- a/test/symbols.jl
+++ b/test/symbols.jl
@@ -14,6 +14,14 @@ function _symbol_to_unicode_tuple()
 end
 @test _symbol_to_unicode_tuple()
 
+function _symbol_to_unicode_dict()
+    ds=Dict(:beta=>0.05, :c_beta=>0.05, :eta=>10.0)
+    nt=RHEOS.symbol_to_unicode(ds) 
+    nt.η==10.0
+end
+@test _symbol_to_unicode_dict()
+
+
 println("===============================================")
 
 


### PR DESCRIPTION
Focus on allowing to pass Dicts as parameters, as a replacement for NamedTuples. This is important to users calling Rheos from Python.
#116 